### PR TITLE
add `-l`/`--latest` flag to pre-fill tag from latest reachable ancestor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/cerik-nguyen/cutver
+module github.com/roryq/cutver
 
 go 1.16
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/roryq/cutver
+module github.com/cerik-nguyen/cutver
 
 go 1.16
 

--- a/main.go
+++ b/main.go
@@ -1,12 +1,15 @@
 package main
 
 import (
+	"flag"
 	"fmt"
-	"github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/plumbing"
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
@@ -14,20 +17,35 @@ import (
 )
 
 func main() {
+	latest := flag.Bool("latest", false, "pre-fill tag with the latest reachable tag from current commit")
+	flag.BoolVar(latest, "l", false, "pre-fill tag with the latest reachable tag from current commit (shorthand)")
+	flag.Parse()
+
 	repo, err := getRepoInfo()
 	if err != nil {
 		fmt.Println("error getting repo information", err)
 		os.Exit(1)
 	}
+
+	initialTag := "v"
+	if *latest {
+		tag, err := getLatestReachableTag(repo.Repository)
+		if err != nil {
+			fmt.Println("error finding latest reachable tag:", err)
+			os.Exit(1)
+		}
+		initialTag = tag
+	}
+
 	resultCommandChan := make(chan string, 1)
-	if err := tea.NewProgram(initialModel(repo.currentBranch, resultCommandChan)).Start(); err != nil {
+	if err := tea.NewProgram(initialModel(repo.currentBranch, initialTag, resultCommandChan)).Start(); err != nil {
 		fmt.Printf("could not start program: %s\n", err)
 		os.Exit(1)
 	}
 
 	select {
 	case result := <-resultCommandChan:
-		if err:= executeCommand(result); err != nil {
+		if err := executeCommand(result); err != nil {
 			fmt.Println("error executing command: ", err.Error())
 			os.Exit(1)
 		}
@@ -46,10 +64,10 @@ func executeCommand(cmdStr string) error {
 
 var (
 	focusedStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
-	cursorStyle = focusedStyle.Copy()
-	noStyle     = lipgloss.NewStyle()
-	lightStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Copy()
-	boldStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("244"))
+	cursorStyle  = focusedStyle.Copy()
+	noStyle      = lipgloss.NewStyle()
+	lightStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Copy()
+	boldStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("244"))
 
 	focusedButton = focusedStyle.Copy().Render("[ Tag and Push ]")
 	blurredButton = fmt.Sprintf("[ %s ]", lightStyle.Render("Tag and Push"))
@@ -62,9 +80,9 @@ type model struct {
 	tagCommandOutChan chan string
 }
 
-func initialModel(branch string, tagCommand chan string) model {
+func initialModel(branch string, initialTag string, tagCommand chan string) model {
 	m := model{
-		inputs: make([]textinput.Model, 2),
+		inputs:            make([]textinput.Model, 2),
 		tagCommandOutChan: tagCommand,
 	}
 
@@ -77,7 +95,7 @@ func initialModel(branch string, tagCommand chan string) model {
 		case 0:
 			t.Focus()
 			t.Placeholder = "tag"
-			t.SetValue("v")
+			t.SetValue(initialTag)
 			t.CharLimit = 64
 			t.PromptStyle = focusedStyle
 			t.TextStyle = focusedStyle
@@ -92,6 +110,7 @@ func initialModel(branch string, tagCommand chan string) model {
 
 	return m
 }
+
 func (m model) Init() tea.Cmd {
 	return textinput.Blink
 }
@@ -122,8 +141,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Did the user press enter while the submit button was focused?
 			// If so, exit.
 			if s == "enter" && m.focusIndex == len(m.inputs) {
-				m.tagCommandOutChan<- strings.Join(m.command(), "")
-				return m, tea.Batch(tea.ExitAltScreen,tea.Quit)
+				m.tagCommandOutChan <- strings.Join(m.command(), "")
+				return m, tea.Batch(tea.ExitAltScreen, tea.Quit)
 			}
 
 			// Cycle indexes
@@ -199,7 +218,7 @@ func (m model) View() string {
 func (m model) command() []string {
 	tag := m.inputs[0].Value()
 	branch := m.inputs[1].Value()
-	command := []string {
+	command := []string{
 		`git tag -a `, tag, ` -m "source=manual,branch=`, branch, `,tag=`, tag,
 		`" && git push origin `, tag,
 	}
@@ -208,7 +227,7 @@ func (m model) command() []string {
 
 func formatLightBold(b *strings.Builder, s ...string) {
 	for i := range s {
-		if i % 2 == 0 {
+		if i%2 == 0 {
 			b.WriteString(lightStyle.Render(s[i]))
 		} else {
 			b.WriteString(boldStyle.Render(s[i]))
@@ -220,6 +239,7 @@ type repoInfo struct {
 	*git.Repository
 	currentBranch string
 }
+
 func getRepoInfo() (*repoInfo, error) {
 	repo, err := git.PlainOpen(".")
 	if err != nil {
@@ -246,4 +266,51 @@ func getRepoInfo() (*repoInfo, error) {
 	})
 
 	return &repoInfo{repo, currentBranch}, nil
+}
+
+// getLatestReachableTag walks commit history from HEAD and returns the name of
+// the closest ancestor tag, mirroring `git describe --tags --abbrev=0`.
+func getLatestReachableTag(repo *git.Repository) (string, error) {
+	headRef, err := repo.Head()
+	if err != nil {
+		return "", err
+	}
+
+	// Build a map of commit hash -> tag name from all tags.
+	tagMap := map[plumbing.Hash]string{}
+	tags, err := repo.Tags()
+	if err != nil {
+		return "", err
+	}
+	_ = tags.ForEach(func(ref *plumbing.Reference) error {
+		// Annotated tag: resolve the tag object to its target commit.
+		if tagObj, err := repo.TagObject(ref.Hash()); err == nil {
+			tagMap[tagObj.Target] = ref.Name().Short()
+		} else {
+			// Lightweight tag: points directly to a commit.
+			tagMap[ref.Hash()] = ref.Name().Short()
+		}
+		return nil
+	})
+
+	// Walk commits from HEAD; stop at the first tagged commit.
+	logIter, err := repo.Log(&git.LogOptions{From: headRef.Hash()})
+	if err != nil {
+		return "", err
+	}
+
+	var found string
+	errStop := fmt.Errorf("stop")
+	_ = logIter.ForEach(func(c *object.Commit) error {
+		if tag, ok := tagMap[c.Hash]; ok {
+			found = tag
+			return errStop
+		}
+		return nil
+	})
+
+	if found == "" {
+		return "", fmt.Errorf("no reachable tags found")
+	}
+	return found, nil
 }


### PR DESCRIPTION
## Summary

- Adds a `-l` / `--latest` flag that walks the commit history from HEAD and pre-fills the tag input with the closest ancestor tag, mirroring `git describe --tags --abbrev=0`
- Without the flag, behaviour is unchanged (tag field starts with `"v"`)
- Uses the existing `go-git` dependency — no new deps required

## Usage

```
cutver -l        # or --latest
```

Opens the TUI with the tag field pre-filled to the latest reachable tag (e.g. `v1.25.0`) so you can edit it before confirming.